### PR TITLE
feat(cf): contest ping (testing)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,10 @@ func main() {
 		log.Fatal("Could not create bot, ", err)
 	}
 
-	cfManager := codeforces.MakeManager()
+	cfManager, err := codeforces.NewManager(session)
+	if err != nil {
+		log.Fatal("Could not create Codeforces manager,", err)
+	}
 
 	session.AddHandler(func(session *discordgo.Session, message *discordgo.MessageCreate) {
 		// Don't react to messages from this bot

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatal("Could not create bot, ", err)
 	}
 
-	cfManager := codeforces.Manager{}
+	cfManager := codeforces.MakeManager()
 
 	session.AddHandler(func(session *discordgo.Session, message *discordgo.MessageCreate) {
 		// Don't react to messages from this bot
@@ -79,12 +79,13 @@ func main() {
 		log.Fatal("Could not open session with token ", err)
 	}
 
+	// Close session when application exits
 	defer func() {
-		err = session.Close() // Close session when application exits
+		err = session.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}()
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	log.Println("Bot is online")
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,4 +86,3 @@ func main() {
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
 }
-

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -19,6 +19,7 @@ type contestList struct {
 }
 
 type contest struct {
+	Pinged                bool
 	ID                    int    `json:"id"`
 	Name                  string `json:"name"`
 	Type                  string `json:"type"`
@@ -46,6 +47,7 @@ type manager struct {
 func MakeManager() manager {
 	man := manager{}
 	man.startContestUpdate()
+	man.startContestPingCheck()
 	return man
 }
 
@@ -59,8 +61,8 @@ func (man *manager) HandleCodeforcesCommands(args []string, session *discordgo.S
 	}
 }
 
+// Start goroutine that updates upcomingContests
 func (man *manager) startContestUpdate() {
-	// Start goroutine that updates upcomingContests whenever the manager's ticker fires
 	go func() {
 		for {
 			// Update once every hour

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -6,10 +6,14 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func HandleCodeforcesCommands(args []string, session *discordgo.Session,
+type Manager struct {
+	upcomingContests []Contest
+}
+
+func (manager *Manager) HandleCodeforcesCommands(args []string, session *discordgo.Session,
 	message *discordgo.MessageCreate) {
 	if args[1] == "contests" {
-		err := listFutureContests(session, message)
+		err := listFutureContests(manager, session, message)
 		if err != nil {
 			log.Println("Listing future Codeforces contests failed, ", err)
 		}

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -45,7 +45,7 @@ type contest struct {
 
 type manager struct {
 	upcomingContests []contest
-	pingChannelIDs []string
+	pingChannelIDs   []string
 }
 
 func NewManager(session *discordgo.Session) (*manager, error) {
@@ -91,9 +91,9 @@ func (man *manager) HandleCodeforcesCommands(args []string, session *discordgo.S
 
 func (man *manager) addDebugContest(name string, startTime int) {
 	man.upcomingContests = append(man.upcomingContests, contest{
-		Name: name,
+		Name:             name,
 		StartTimeSeconds: startTime,
-		Pinged: false,
+		Pinged:           false,
 	})
 }
 

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -1,10 +1,42 @@
 package codeforces
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"log"
+	"net/http"
+	"sort"
 
 	"github.com/bwmarrin/discordgo"
 )
+
+type contestList struct {
+	Status   string    `json:"status"`
+	Contests []contest `json:"result"`
+	Comment  string    `json:"comment,omitempty"`
+}
+
+type contest struct {
+	ID                    int    `json:"id"`
+	Name                  string `json:"name"`
+	Type                  string `json:"type"`
+	Phase                 string `json:"phase"`
+	Frozen                bool   `json:"frozen"`
+	DurationSeconds       int    `json:"durationSeconds"`
+	Description           string `json:"description,omitempty"`
+	Difficulty            int    `json:"difficulty,omitempty"`
+	Kind                  string `json:"kind,omitempty"`
+	Season                string `json:"season,omitempty"`
+	StartTimeSeconds      int    `json:"startTimeSeconds,omitempty"`
+	RelativeTimeSeconds   int    `json:"relativeTimeSeconds,omitempty"`
+	PreparedBy            string `json:"preparedBy,omitempty"`
+	Country               string `json:"country,omitempty"`
+	City                  string `json:"city,omitempty"`
+	IcpcRegion            string `json:"icpcRegion,omitempty"`
+	WebsiteURL            string `json:"websiteUrl,omitempty"`
+	FreezeDurationSeconds int    `json:"freezeDurationSeconds,omitempty"`
+}
 
 type Manager struct {
 	upcomingContests []contest
@@ -18,4 +50,53 @@ func (manager *Manager) HandleCodeforcesCommands(args []string, session *discord
 			log.Println("Listing future Codeforces contests failed, ", err)
 		}
 	}
+}
+
+func (manager *Manager) updateUpcomingContests() error {
+	contests, err := getContests()
+	if err != nil {
+		return err
+	}
+
+	if contests.Status == "FAILED" {
+		return errors.New(contests.Comment)
+	}
+
+	// Find all current or future contests
+	var upcoming []contest
+	for _, contest := range contests.Contests {
+		if contest.Phase == "BEFORE" || contest.Phase == "CODING" {
+			upcoming = append(upcoming, contest)
+		}
+	}
+
+	// Sort upcoming contests by starting time
+	sort.Slice(upcoming, func(i, j int) bool {
+		return upcoming[i].StartTimeSeconds < upcoming[j].StartTimeSeconds
+	})
+
+	manager.upcomingContests = upcoming
+	return nil
+}
+
+func getContests() (contests *contestList, err error) {
+	res, err := http.Get("https://codeforces.com/api/contest.list")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err == nil {
+			err = res.Body.Close()
+		}
+	}()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var contestList contestList
+	err = json.Unmarshal(body, &contestList)
+
+	return &contestList, err
 }

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -42,13 +42,18 @@ type contest struct {
 
 type manager struct {
 	upcomingContests []contest
+	pingChannelIDs []string
 }
 
-func MakeManager() manager {
-	man := manager{}
+func NewManager(session *discordgo.Session) (*manager, error) {
+	man := new(manager)
 	man.startContestUpdate()
 	man.startContestPingCheck()
-	return man
+	err := man.initPingChannel(session)
+	if err != nil {
+		return nil, err
+	}
+	return man, nil
 }
 
 func (man *manager) HandleCodeforcesCommands(args []string, session *discordgo.Session,

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -7,9 +7,12 @@ import (
 	"log"
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+
+	"github.com/yuqzii/konkurransetilsynet/internal"
 )
 
 type contestList struct {
@@ -58,12 +61,40 @@ func NewManager(session *discordgo.Session) (*manager, error) {
 
 func (man *manager) HandleCodeforcesCommands(args []string, session *discordgo.Session,
 	message *discordgo.MessageCreate) {
-	if args[1] == "contests" {
+	switch args[1] {
+	case "contests":
 		err := man.listFutureContests(session, message)
 		if err != nil {
 			log.Println("Listing future Codeforces contests failed, ", err)
 		}
+	case "addDebugContest":
+		if len(args) != 5 {
+			err := messageCommands.UnknownCommand(session, message)
+			if err != nil {
+				log.Println("UnknownCommand failed, ", err)
+			}
+			return
+		}
+
+		startTime, err := strconv.Atoi(args[4])
+		if err != nil {
+			err = messageCommands.UnknownCommand(session, message)
+			if err != nil {
+				log.Println("UnknownCommand failed, ", err)
+			}
+			return
+		}
+
+		man.addDebugContest(args[3], startTime)
 	}
+}
+
+func (man *manager) addDebugContest(name string, startTime int) {
+	man.upcomingContests = append(man.upcomingContests, contest{
+		Name: name,
+		StartTimeSeconds: startTime,
+		Pinged: false,
+	})
 }
 
 // Start goroutine that updates upcomingContests

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -7,13 +7,13 @@ import (
 )
 
 type Manager struct {
-	upcomingContests []Contest
+	upcomingContests []contest
 }
 
 func (manager *Manager) HandleCodeforcesCommands(args []string, session *discordgo.Session,
 	message *discordgo.MessageCreate) {
 	if args[1] == "contests" {
-		err := listFutureContests(manager, session, message)
+		err := manager.listFutureContests(session, message)
 		if err != nil {
 			log.Println("Listing future Codeforces contests failed, ", err)
 		}

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -48,7 +48,7 @@ type manager struct {
 func NewManager(session *discordgo.Session) (*manager, error) {
 	man := new(manager)
 	man.startContestUpdate()
-	man.startContestPingCheck()
+	man.startContestPingCheck(session)
 	err := man.initPingChannel(session)
 	if err != nil {
 		return nil, err

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -2,6 +2,7 @@ package codeforces
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -22,8 +23,11 @@ func (man *manager) startContestPingCheck(session *discordgo.Session) {
 
 func (man *manager) checkContestPing(session *discordgo.Session) {
 	for _, contest := range man.upcomingContests {
-		if contest.StartTimeSeconds-int(time.Now().Unix()) <= pingTime && !contest.Pinged {
-			man.contestPing(&contest, session)
+		if contest.StartTimeSeconds - int(time.Now().Unix()) <= pingTime && !contest.Pinged {
+			err := man.contestPing(&contest, session)
+			if err != nil {
+				log.Println("Automatic contest ping failed, ", err)
+			}
 		}
 	}
 }

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -23,7 +23,7 @@ func (man *manager) startContestPingCheck(session *discordgo.Session) {
 
 func (man *manager) checkContestPing(session *discordgo.Session) {
 	for _, contest := range man.upcomingContests {
-		if contest.StartTimeSeconds - int(time.Now().Unix()) <= pingTime && !contest.Pinged {
+		if contest.StartTimeSeconds-int(time.Now().Unix()) <= pingTime && !contest.Pinged {
 			err := man.contestPing(&contest, session)
 			if err != nil {
 				log.Println("Automatic contest ping failed, ", err)

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -22,26 +22,26 @@ func (man *manager) startContestPingCheck(session *discordgo.Session) {
 
 func (man *manager) checkContestPing(session *discordgo.Session) {
 	for _, contest := range man.upcomingContests {
-		if contest.StartTimeSeconds - int(time.Now().Unix()) <= pingTime && !contest.Pinged {
+		if contest.StartTimeSeconds-int(time.Now().Unix()) <= pingTime && !contest.Pinged {
 			man.contestPing(&contest, session)
 		}
 	}
 }
 
 func (man *manager) contestPing(contest *contest, session *discordgo.Session) error {
-    contest.Pinged = true
+	contest.Pinged = true
 
-    for _, channel := range man.pingChannelIDs {
-        // !!!! UPDATE FOR PRODUCTION, using temporary hardcoded role id
-        _, err := session.ChannelMessageSend(channel,
-            fmt.Sprint("<@&1369025298359648358>", contest.Name,
-            fmt.Sprintf("is starting <t:%d:R>", contest.StartTimeSeconds)))
-        if err != nil {
-            return err
-        }
-    }
+	for _, channel := range man.pingChannelIDs {
+		// !!!! UPDATE FOR PRODUCTION, using temporary hardcoded role id
+		_, err := session.ChannelMessageSend(channel,
+			fmt.Sprint("<@&1369025298359648358>", contest.Name,
+				fmt.Sprintf("is starting <t:%d:R>", contest.StartTimeSeconds)))
+		if err != nil {
+			return err
+		}
+	}
 
-    return nil
+	return nil
 }
 
 func (man *manager) initPingChannel(session *discordgo.Session) error {
@@ -75,7 +75,7 @@ func (man *manager) initPingChannel(session *discordgo.Session) error {
 			if err != nil {
 				return err
 			}
-			
+
 			pingChannel = newChannel.ID
 		}
 

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -1,0 +1,28 @@
+package codeforces
+
+import "time"
+
+const pingTime int = 1 * 3600 // 1 hour
+
+// Start goroutine that checks whether it should issue a ping for upcoming contests
+func (man *manager) startContestPingCheck() {
+	go func() {
+		for {
+			time.Sleep(1 * time.Minute)
+
+			man.checkContestPing()
+		}
+	}()
+}
+
+func (man *manager) checkContestPing() {
+	for _, contest := range man.upcomingContests {
+		if contest.StartTimeSeconds - int(time.Now().Unix()) <= pingTime && !contest.Pinged {
+			contestPing(&contest)
+		}
+	}
+}
+
+func contestPing(contest *contest) {
+	contest.Pinged = true
+}

--- a/internal/codeforces/listContests.go
+++ b/internal/codeforces/listContests.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func (manager *Manager) listFutureContests(session *discordgo.Session,
+func (manager *manager) listFutureContests(session *discordgo.Session,
 	message *discordgo.MessageCreate) error {
 
 	err := manager.updateUpcomingContests()

--- a/internal/codeforces/listContests.go
+++ b/internal/codeforces/listContests.go
@@ -39,7 +39,9 @@ type Contest struct {
 	FreezeDurationSeconds int    `json:"freezeDurationSeconds,omitempty"`
 }
 
-func listFutureContests(session *discordgo.Session, message *discordgo.MessageCreate) error {
+func listFutureContests(manager *Manager, session *discordgo.Session,
+	message *discordgo.MessageCreate) error {
+
 	contests, err := getFromAPI()
 	if err != nil {
 		return err
@@ -63,6 +65,8 @@ func listFutureContests(session *discordgo.Session, message *discordgo.MessageCr
 			upcoming = append(upcoming, contest)
 		}
 	}
+
+	manager.upcomingContests = upcoming
 
 	// Sort upcoming contests by starting time
 	sort.Slice(upcoming, func(i, j int) bool {

--- a/internal/codeforces/listContests.go
+++ b/internal/codeforces/listContests.go
@@ -43,4 +43,3 @@ func (manager *manager) listFutureContests(session *discordgo.Session,
 	_, err = session.ChannelMessageSendEmbed(message.ChannelID, &embed)
 	return err
 }
-

--- a/internal/codeforces/listContests.go
+++ b/internal/codeforces/listContests.go
@@ -12,13 +12,13 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-type ContestList struct {
+type contestList struct {
 	Status   string    `json:"status"`
-	Contests []Contest `json:"result"`
+	Contests []contest `json:"result"`
 	Comment  string    `json:"comment,omitempty"`
 }
 
-type Contest struct {
+type contest struct {
 	ID                    int    `json:"id"`
 	Name                  string `json:"name"`
 	Type                  string `json:"type"`
@@ -39,7 +39,7 @@ type Contest struct {
 	FreezeDurationSeconds int    `json:"freezeDurationSeconds,omitempty"`
 }
 
-func listFutureContests(manager *Manager, session *discordgo.Session,
+func (manager *Manager) listFutureContests(session *discordgo.Session,
 	message *discordgo.MessageCreate) error {
 
 	contests, err := getFromAPI()
@@ -59,7 +59,7 @@ func listFutureContests(manager *Manager, session *discordgo.Session,
 	}
 
 	// Find all current or future contests
-	var upcoming []Contest
+	var upcoming []contest
 	for _, contest := range contests.Contests {
 		if contest.Phase == "BEFORE" || contest.Phase == "CODING" {
 			upcoming = append(upcoming, contest)
@@ -95,7 +95,7 @@ func listFutureContests(manager *Manager, session *discordgo.Session,
 	return err
 }
 
-func getFromAPI() (contests *ContestList, err error) {
+func getFromAPI() (contests *contestList, err error) {
 	res, err := http.Get("https://codeforces.com/api/contest.list")
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func getFromAPI() (contests *ContestList, err error) {
 		return nil, err
 	}
 
-	var contestList ContestList
+	var contestList contestList
 	err = json.Unmarshal(body, &contestList)
 
 	return &contestList, err


### PR DESCRIPTION
Related issue: #12 (do not close yet, feature not finalized)
- Create manager to store information such as upcoming contests
- Periodically update contest list every hour using goroutines. (Still updated with `!cf contests` command to ensure up-to-date information).
- Continously check upcoming contests' start time to find out if we should issue a ping for that contest, also using goroutines.
- Automatically find channel named "contest-pings" to, surprisingly, send pings in. Creates this channel if none is found.
- Command to add a fake debug contest, see e788a2a for details.