### PR TITLE
bugfix(cf): pinging contest multiple times

### DIFF
--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -16,9 +16,9 @@ import (
 )
 
 type contestList struct {
-	Status   string    `json:"status"`
+	Status   string     `json:"status"`
 	Contests []*contest `json:"result"`
-	Comment  string    `json:"comment,omitempty"`
+	Comment  string     `json:"comment,omitempty"`
 }
 
 type contest struct {

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -89,7 +89,10 @@ func (man *manager) HandleCodeforcesCommands(args []string, session *discordgo.S
 
 		man.addDebugContest(args[2], startTime)
 	default:
-		messageCommands.UnknownCommand(session, message)
+		err := messageCommands.UnknownCommand(session, message)
+		if err != nil {
+			log.Println("UnkownCommand failed, ", err)
+		}
 	}
 
 }

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -17,7 +17,7 @@ import (
 
 type contestList struct {
 	Status   string    `json:"status"`
-	Contests []contest `json:"result"`
+	Contests []*contest `json:"result"`
 	Comment  string    `json:"comment,omitempty"`
 }
 
@@ -126,7 +126,7 @@ func (man *manager) updateUpcomingContests() error {
 	var upcoming []*contest
 	for _, contest := range contests.Contests {
 		if contest.Phase == "BEFORE" || contest.Phase == "CODING" {
-			upcoming = append(upcoming, &contest)
+			upcoming = append(upcoming, contest)
 		}
 	}
 

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -44,7 +44,7 @@ type contest struct {
 }
 
 type manager struct {
-	upcomingContests []contest
+	upcomingContests []*contest
 	pingChannelIDs   []string
 }
 
@@ -90,7 +90,7 @@ func (man *manager) HandleCodeforcesCommands(args []string, session *discordgo.S
 }
 
 func (man *manager) addDebugContest(name string, startTime int) {
-	man.upcomingContests = append(man.upcomingContests, contest{
+	man.upcomingContests = append(man.upcomingContests, &contest{
 		Name:             name,
 		StartTimeSeconds: startTime,
 		Pinged:           false,
@@ -123,10 +123,10 @@ func (man *manager) updateUpcomingContests() error {
 	}
 
 	// Find all current or future contests
-	var upcoming []contest
+	var upcoming []*contest
 	for _, contest := range contests.Contests {
 		if contest.Phase == "BEFORE" || contest.Phase == "CODING" {
-			upcoming = append(upcoming, contest)
+			upcoming = append(upcoming, &contest)
 		}
 	}
 

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -25,7 +25,7 @@ func (man *manager) checkContestPing(session *discordgo.Session) {
 	for _, contest := range man.upcomingContests {
 		if contest.StartTimeSeconds-int(time.Now().Unix()) <= pingTime && !contest.Pinged {
 			log.Println("Pinging contest", contest.Name)
-			err := man.contestPing(&contest, session)
+			err := man.contestPing(contest, session)
 			if err != nil {
 				log.Println("Automatic contest ping failed, ", err)
 			}
@@ -81,10 +81,12 @@ func (man *manager) initPingChannel(session *discordgo.Session) error {
 				return err
 			}
 
+			log.Println("Created ping channel, ", newChannel.ID)
 			pingChannel = newChannel.ID
 		}
 
 		man.pingChannelIDs = append(man.pingChannelIDs, pingChannel)
+		log.Println("Found ping channel, ", pingChannel)
 	}
 
 	return nil

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -22,8 +22,10 @@ func (man *manager) startContestPingCheck(session *discordgo.Session) {
 }
 
 func (man *manager) checkContestPing(session *discordgo.Session) {
+	curTime := int(time.Now().Unix())
 	for _, contest := range man.upcomingContests {
-		if contest.StartTimeSeconds-int(time.Now().Unix()) <= pingTime && !contest.Pinged {
+		shouldPing := contest.StartTimeSeconds-curTime <= pingTime
+		if shouldPing && !contest.Pinged {
 			log.Println("Pinging contest", contest.Name)
 			err := man.contestPing(contest, session)
 			if err != nil {
@@ -34,6 +36,8 @@ func (man *manager) checkContestPing(session *discordgo.Session) {
 }
 
 func (man *manager) contestPing(contest *contest, session *discordgo.Session) error {
+	man.mu.Lock()
+	defer man.mu.Unlock()
 	contest.Pinged = true
 
 	for _, channel := range man.pingChannelIDs {

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -22,7 +22,6 @@ func (man *manager) startContestPingCheck(session *discordgo.Session) {
 }
 
 func (man *manager) checkContestPing(session *discordgo.Session) {
-	log.Println("Checking contests for ping")
 	for _, contest := range man.upcomingContests {
 		if contest.StartTimeSeconds-int(time.Now().Unix()) <= pingTime && !contest.Pinged {
 			log.Println("Pinging contest", contest.Name)


### PR DESCRIPTION
Closes #36
Problem:
When iterating over upcomingContests a copy of the contest is created,
which makes it impossible to modify the contest stored inside
upcomingContests when iterating over it.

Solution:
Store upcomingContests as pointers to contests, when a copy if this
value is made it will still point to the same variable.
(copied from commit e9cd57aff110d0b147ca71592f2fe10ca86fe931)