### PR TITLE
fix(cf): try initing ping channel after session opens

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,6 +72,11 @@ func main() {
 		log.Fatal("Could not open session with token ", err)
 	}
 
+	err = cfManager.InitPingChannel(session)
+	if err != nil {
+		log.Println("Could not initialize Codeforces ping channel, ", err)
+	}
+
 	// Close session when application exits
 	defer func() {
 		err = session.Close()

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -54,10 +54,6 @@ func NewManager(session *discordgo.Session) (*manager, error) {
 	man := new(manager)
 	man.startContestUpdate()
 	man.startContestPingCheck(session)
-	err := man.initPingChannel(session)
-	if err != nil {
-		return nil, err
-	}
 	return man, nil
 }
 

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -53,7 +53,7 @@ func (man *manager) contestPing(contest *contest, session *discordgo.Session) er
 	return nil
 }
 
-func (man *manager) initPingChannel(session *discordgo.Session) error {
+func (man *manager) InitPingChannel(session *discordgo.Session) error {
 	const channelName string = "contest-pings"
 
 	// Clear pingChannelIDs of possible existing IDs


### PR DESCRIPTION
Related issue: #34 
I suspect that the bot fails to find/create a ping channel because it does not have access to the list of connected guilds before the session is opened.