### PR TITLE
feat(cf): find or create ping role

### DIFF
--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -36,7 +36,7 @@ type contest struct {
 	Kind                  string `json:"kind,omitempty"`
 	Season                string `json:"season,omitempty"`
 	StartTimeSeconds      uint32 `json:"startTimeSeconds,omitempty"`
-	RelativeTimeSeconds   int32 `json:"relativeTimeSeconds,omitempty"`
+	RelativeTimeSeconds   int32  `json:"relativeTimeSeconds,omitempty"`
 	PreparedBy            string `json:"preparedBy,omitempty"`
 	Country               string `json:"country,omitempty"`
 	City                  string `json:"city,omitempty"`

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -56,7 +56,7 @@ var upcoming = contestList{}
 
 func Init(s *discordgo.Session) error {
 	startContestUpdate(&upcoming, 1*time.Hour)
-	if err := updatePingChannels(s); err != nil {
+	if err := updatePingData(s); err != nil {
 		return err
 	}
 	startContestPingCheck(&upcoming, 1*time.Minute, s)

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -72,29 +72,13 @@ func HandleCodeforcesCommands(args []string, s *discordgo.Session, m *discordgo.
 
 		err := listContests(&upcoming, s, m)
 		if err != nil {
-			return errors.Join(errors.New("listing future contests failed"), err)
+			return errors.Join(errors.New("listing future contests failed,"), err)
 		}
 	case "addDebugContest":
-		if len(args) != 5 {
-			err := messageCommands.UnknownCommand(s, m)
-			return err
-		}
-
-		startTime64, err := strconv.ParseUint(args[3], 10, 32)
+		err := addDebugContestCommand(args, s, m)
 		if err != nil {
-			err = errors.Join(err, messageCommands.UnknownCommand(s, m))
-			return err
+			return errors.Join(errors.New("adding debug contest failed,"), err)
 		}
-		startTime := uint32(startTime64)
-
-		id64, err := strconv.ParseUint(args[4], 10, 32)
-		if err != nil {
-			err = errors.Join(err, messageCommands.UnknownCommand(s, m))
-			return err
-		}
-		id := uint32(id64)
-
-		addContest(&upcoming, id, args[2], startTime)
 	default:
 		err := messageCommands.UnknownCommand(s, m)
 		return err
@@ -114,6 +98,30 @@ func startContestUpdate(listToUpdate *contestList, interval time.Duration) {
 			}
 		}
 	}()
+}
+
+func addDebugContestCommand(args []string, s *discordgo.Session, m *discordgo.MessageCreate) error {
+	if len(args) != 5 {
+		err := messageCommands.UnknownCommand(s, m)
+		return err
+	}
+
+	startTime64, err := strconv.ParseUint(args[3], 10, 32)
+	if err != nil {
+		err = errors.Join(err, messageCommands.UnknownCommand(s, m))
+		return err
+	}
+	startTime := uint32(startTime64)
+
+	id64, err := strconv.ParseUint(args[4], 10, 32)
+	if err != nil {
+		err = errors.Join(err, messageCommands.UnknownCommand(s, m))
+		return err
+	}
+	id := uint32(id64)
+
+	addContest(&upcoming, id, args[2], startTime)
+	return nil
 }
 
 func addContest(contests *contestList, id uint32, name string, startTime uint32) {

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -53,7 +53,8 @@ func checkContestPing(contests *contestList, session *discordgo.Session) error {
 				return errors.Join(errors.New("failed to ping contest,"), err)
 			}
 		} else if !shouldPing {
-			// Contests are sorted, so no more contests should be pinged after the first that should
+			// Contests are sorted, so no more contests should be pinged after
+			// the first that should not
 			break
 		}
 	}
@@ -70,8 +71,8 @@ func contestPing(contests *contestList, idx int, session *discordgo.Session) err
 
 	pingList.mu.RLock()
 	defer pingList.mu.RUnlock()
+	// Issue ping for every ping channel (essentially for every server)
 	for _, data := range pingList.list {
-		// TODO: Find role id belonging to each server and ping it
 		_, err := session.ChannelMessageSend(data.channel,
 			fmt.Sprintf("<@&%s> **%s** is starting <t:%d:R>",
 				data.role, contests.contests[idx].Name, contests.contests[idx].StartTimeSeconds))
@@ -90,9 +91,8 @@ func updatePingData(s *discordgo.Session) error {
 	}
 
 	pingList.mu.Lock()
-	defer pingList.mu.Unlock()
-
 	pingList.list = data
+	pingList.mu.Unlock()
 	return nil
 }
 

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -50,7 +50,7 @@ func checkContestPing(contests *contestList, session *discordgo.Session) error {
 		if shouldPing && !isPinged {
 			err := contestPing(contests, i, session)
 			if err != nil {
-				return errors.Join(errors.New("failed to ping contest:"), err)
+				return errors.Join(errors.New("failed to ping contest,"), err)
 			}
 		} else if !shouldPing {
 			// Contests are sorted, so no more contests should be pinged after the first that should
@@ -145,7 +145,7 @@ func getPingData(s *discordgo.Session, channelName string, roleName string) ([]p
 				Name: roleName,
 			})
 			if err != nil {
-				return nil, errors.Join(errors.New("failed to create ping role:"), err)
+				return nil, errors.Join(errors.New("failed to create ping role,"), err)
 			}
 
 			pingRole = newRole.ID

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -154,7 +154,7 @@ func getChannelIDByName(name string, guildID string, s *discordgo.Session) (stri
 			return channel.ID, nil
 		}
 	}
-	
+
 	return "", nil
 }
 

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -69,8 +69,8 @@ func contestPing(contests *contestList, idx int, session *discordgo.Session) err
 	for _, data := range pingList.list {
 		// TODO: Find role id belonging to each server and ping it
 		_, err := session.ChannelMessageSend(data.channel,
-			fmt.Sprint("@<role> ", contests.contests[idx].Name,
-				fmt.Sprintf(" is starting <t:%d:R>", contests.contests[idx].StartTimeSeconds)))
+			fmt.Sprintf("<@&%s> **%s** is starting <t:%d:R>",
+				data.role, contests.contests[idx].Name, contests.contests[idx].StartTimeSeconds))
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func getPingData(s *discordgo.Session) ([]pingData, error) {
 		// Create ping role if server does not have one
 		if pingRole == "" {
 			newRole, err := s.GuildRoleCreate(guild.ID, &discordgo.RoleParams{
-				Name: roleName,
+				Name:        roleName,
 				Mentionable: boolPointer(true),
 			})
 			if err != nil {

--- a/internal/codeforces/contestPing.go
+++ b/internal/codeforces/contestPing.go
@@ -84,7 +84,7 @@ func contestPing(contests *contestList, idx int, session *discordgo.Session) err
 }
 
 func updatePingData(s *discordgo.Session) error {
-	data, err := getPingData(s)
+	data, err := getPingData(s, "contest-pings", "Contest Ping")
 	if err != nil {
 		return err
 	}
@@ -96,10 +96,7 @@ func updatePingData(s *discordgo.Session) error {
 	return nil
 }
 
-func getPingData(s *discordgo.Session) ([]pingData, error) {
-	const channelName string = "contest-pings"
-	const roleName string = "Contest Ping"
-
+func getPingData(s *discordgo.Session, channelName string, roleName string) ([]pingData, error) {
 	var result []pingData
 
 	for _, guild := range s.State.Guilds {
@@ -127,7 +124,6 @@ func getPingData(s *discordgo.Session) ([]pingData, error) {
 				return nil, err
 			}
 
-			log.Println("Created ping channel,", newChannel.ID)
 			pingChannel = newChannel.ID
 		}
 
@@ -146,25 +142,17 @@ func getPingData(s *discordgo.Session) ([]pingData, error) {
 		// Create ping role if server does not have one
 		if pingRole == "" {
 			newRole, err := s.GuildRoleCreate(guild.ID, &discordgo.RoleParams{
-				Name:        roleName,
-				Mentionable: boolPointer(true),
+				Name: roleName,
 			})
 			if err != nil {
 				return nil, errors.Join(errors.New("failed to create ping role:"), err)
 			}
 
-			log.Println("Created ping role:", newRole.ID)
 			pingRole = newRole.ID
 		}
 
 		result = append(result, pingData{pingChannel, pingRole})
-		log.Println("Found ping channel,", pingChannel)
 	}
 
 	return result, nil
-}
-
-// GuildRoleCreate wants a *bool, which cannot be made easily without a helper function like this
-func boolPointer(b bool) *bool {
-	return &b
 }


### PR DESCRIPTION
Closes #40 
- Attempts to find a role with the supplied name and stores its ID for ping. If a role with the supplied name does not exist, one will be created with that name.
- Correctly formats the ping message to ping the role
- Fix issue where there could be more mutex locks than unlocks
- Tracks pinged contests by ID to avoid possible re-ping of contest. See 231f388cb4cc85b9e5cd278469c97595ecf4c4ed