### PR TITLE
feat: codeforces authentication

### DIFF
--- a/dbinit/user_data.sql
+++ b/dbinit/user_data.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS user_data (
 	discord_id NUMERIC(20) NOT NULL,
-	codeforces_name VARCHAR(255) NOT NULL
+	codeforces_name VARCHAR(255)
 );
 
 ALTER TABLE user_data

--- a/dbinit/user_data.sql
+++ b/dbinit/user_data.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS user_data (
 	discord_id NUMERIC(20) NOT NULL,
-	codeforces_name VARCHAR(255)
+	codeforces_handle VARCHAR(255)
 );
 
 ALTER TABLE user_data

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -59,7 +59,7 @@ func authCommand(args []string, s *discordgo.Session, m *discordgo.MessageCreate
 		return err
 	}
 
-	log.Printf("Received codeforces authenticate for user with handle '%s' from %s (%s).",
+	log.Printf("Received Codeforces authenticate for user with handle '%s' from %s (%s).",
 		args[2], m.Author.ID, m.Author.Username)
 
 	connectedHandle, err := database.GetConnectedCodeforces(m.Author.ID, args[2])
@@ -78,7 +78,7 @@ func authCommand(args []string, s *discordgo.Session, m *discordgo.MessageCreate
 
 	userExists, err := checkUserExistence(args[2])
 	if err != nil {
-		return fmt.Errorf("failed to check existance of user: %w", err)
+		return fmt.Errorf("failed to check existence of Codeforces user '%s': %w", args[2], err)
 	}
 	if !userExists {
 		log.Printf("Codeforces user with handle '%s' does not exist.", args[2])
@@ -97,9 +97,9 @@ func authCommand(args []string, s *discordgo.Session, m *discordgo.MessageCreate
 }
 
 func onAlreadyConnected(handle string, s *discordgo.Session, m *discordgo.MessageCreate) error {
-	log.Printf("Discord user %s (%s) is already connected to codeforces user '%s'.",
+	log.Printf("Discord user %s (%s) is already connected to Codeforces user '%s'.",
 		m.Author.ID, m.Author.Username, handle)
-	msgStr := fmt.Sprintf("<@%s> is already connected to the codeforces user '%s'.", m.Author.ID, handle)
+	msgStr := fmt.Sprintf("<@%s> is already connected to the Codeforces user '%s'.", m.Author.ID, handle)
 	_, err := s.ChannelMessageSend(m.ChannelID, msgStr)
 	return err
 }
@@ -112,7 +112,7 @@ func checkUserExistence(handle string) (exists bool, err error) {
 	apiStr := fmt.Sprintf("https://codeforces.com/api/user.info?handles=%s&checkHistoricHandles=false", handle)
 	res, err := http.Get(apiStr)
 	if err != nil {
-		return false, fmt.Errorf("failed to call codeforces user.info api: %w", err)
+		return false, fmt.Errorf("failed to call Codeforces user.info api: %w", err)
 	}
 	defer func() {
 		err = errors.Join(err, res.Body.Close())
@@ -132,7 +132,7 @@ func checkUserExistence(handle string) (exists bool, err error) {
 
 func onUserNotExist(handle string, s *discordgo.Session, m *discordgo.MessageCreate) error {
 	_, err := s.ChannelMessageSend(m.ChannelID,
-		fmt.Sprintf("Could not find a codeforces user with the name '%s', are you sure you spelled it correctly?",
+		fmt.Sprintf("Could not find a Codeforces user with the name '%s', are you sure you spelled it correctly?",
 			handle))
 	return err
 }
@@ -185,10 +185,10 @@ func onAuthSuccess(handle string, s *discordgo.Session, m *discordgo.MessageCrea
 		// Did it fail because the user already exists in the database?
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" { // 23505 is unique violation error code
-			log.Printf("Discord user %s (%s) trying to authenticate for codeforces handle "+
+			log.Printf("Discord user %s (%s) trying to authenticate for Codeforces handle "+
 				"'%s' already exists in the database.",
 				m.Author.ID, m.Author.Username, handle)
-			msgStr := fmt.Sprintf("<@%s> is already connected to a codeforces user.", m.Author.ID)
+			msgStr := fmt.Sprintf("<@%s> is already connected to a Codeforces user.", m.Author.ID)
 			_, err = s.ChannelMessageSend(m.ChannelID, msgStr)
 			return err
 		}
@@ -204,13 +204,13 @@ func onAuthSuccess(handle string, s *discordgo.Session, m *discordgo.MessageCrea
 	}
 
 	// Tell user that the authentication succeeded
-	msgStr := fmt.Sprintf("Successfully authenticated discord user <@%s> with codeforces handle '%s'", m.Author.ID, handle)
+	msgStr := fmt.Sprintf("Successfully authenticated discord user <@%s> with Codeforces handle '%s'", m.Author.ID, handle)
 	_, err = s.ChannelMessageSend(m.ChannelID, msgStr)
 	if err != nil {
 		return fmt.Errorf("failed to send authentication success message: %w", err)
 	}
 
-	log.Printf("Successfully authenticated discord user %s (%s) with codeforces handle '%s'",
+	log.Printf("Successfully authenticated discord user %s (%s) with Codeforces handle '%s'",
 		m.Author.ID, m.Author.Username, handle)
 	return nil
 }
@@ -218,7 +218,7 @@ func onAuthSuccess(handle string, s *discordgo.Session, m *discordgo.MessageCrea
 func onAuthFail(handle string, prob *problem, s *discordgo.Session, m *discordgo.MessageCreate) error {
 	// Send message explaining that the authentication failed
 	probLink := fmt.Sprintf("https://codeforces.com/problemset/problem/%d/%s", prob.ContestID, prob.Index)
-	msgStr := fmt.Sprintf("Authentication for codeforces user with handle '%s' failed. "+
+	msgStr := fmt.Sprintf("Authentication for Codeforces user with handle '%s' failed. "+
 		"Did not find a compilation error submitted to [%s - %d%s](%s). <@%s>",
 		handle, prob.Name, prob.ContestID, prob.Index, probLink, m.Author.ID)
 	_, err := s.ChannelMessageSend(m.ChannelID, msgStr)
@@ -272,7 +272,7 @@ func getProblems() (problems []problem, err error) {
 
 func startAuthCheck(handle string, contID int, problemIdx string, timeoutSeconds int, resultChan chan<- bool) {
 	startTime := time.Now().Unix()
-	log.Printf("Starting codeforces authentication check for user with handle '%s'.", handle)
+	log.Printf("Starting Codeforces authentication check for user with handle '%s'.", handle)
 	go func() {
 		for {
 			// Stop if elapsed time has exceeded the timeout limit

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -228,7 +228,7 @@ func onAuthFail(handle string, prob *problem, s *discordgo.Session, m *discordgo
 	return nil
 }
 
-func getRandomProblem() (*problem, error) {
+func getRandomProblem() (prob *problem, err error) {
 	problems, err := getProblems()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get problems: %w", err)
@@ -236,7 +236,12 @@ func getRandomProblem() (*problem, error) {
 	if len(problems) == 0 {
 		return nil, errors.New("cannot get random problem from empty slice.")
 	}
-	return &problems[rand.Intn(len(problems))], nil
+
+	// Max rating for Codeforces so that most can solve it after submitting compilation error
+	for prob == nil || prob.Rating > 1500 {
+		prob = &problems[rand.Intn(len(problems))]
+	}
+	return prob, err
 }
 
 func getProblems() (problems []problem, err error) {

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -136,19 +136,22 @@ func onUserNotExist(handle string, s *discordgo.Session, m *discordgo.MessageCre
 	return err
 }
 
-//var testProblem *problem = &problem{
-//	ContestID: 1627,
-//	Index:     "C",
-//	Name:      "Not Assigning",
-//	Rating:    1400,
-//}
-
 func authenticate(handle string, s *discordgo.Session, m *discordgo.MessageCreate) error {
 	prob, err := getRandomProblem()
 	if err != nil {
 		return err
 	}
-	//prob = testProblem
+
+	const debug bool = true
+	if debug {
+		var testProblem *problem = &problem{
+			ContestID: 1627,
+			Index:     "C",
+			Name:      "Not Assigning",
+			Rating:    1400,
+		}
+		prob = testProblem
+	}
 
 	err = sendAuthInstructions(prob, s, m)
 	if err != nil {

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -92,13 +92,10 @@ func authCommand(args []string, s *discordgo.Session, m *discordgo.MessageCreate
 		return err
 	}
 
-	// Start authentication goroutine
-	go func() {
-		err := authenticate(args[2], s, m)
-		if err != nil {
-			log.Println("Authentication failed:", err)
-		}
-	}()
+	err = authenticate(args[2], s, m)
+	if err != nil {
+		log.Println("Authentication failed:", err)
+	}
 	return nil
 }
 
@@ -320,7 +317,6 @@ func startAuthCheck(handle string, contID int, problemIdx string, timeoutSeconds
 				close(resultChan)
 				return
 			}
-			// Check every 5 seconds
 			time.Sleep(submissionCheckInteval)
 			// Get submissions and check if any of them match the criteria
 			subs, err := getSubmissions(handle, submissionCheckCount)

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -129,12 +129,10 @@ func authenticate(handle string, s *discordgo.Session, m *discordgo.MessageCreat
 }
 
 func sendAuthInstructions(prob *problem, s *discordgo.Session, m *discordgo.MessageCreate) error {
-	embed := discordgo.MessageEmbed{
-		Title: fmt.Sprintf("Submit a compilation error to %d%s (%s) to authenticate",
-			prob.ContestID, prob.Index, prob.Name),
-		URL: fmt.Sprintf("https://codeforces.com/problemset/problem/%d/%s", prob.ContestID, prob.Index),
-	}
-	_, err := s.ChannelMessageSendEmbed(m.ChannelID, &embed)
+	probLink := fmt.Sprintf("https://codeforces.com/problemset/problem/%d/%s", prob.ContestID, prob.Index)
+	msgStr := fmt.Sprintf("Submit a compilation error to [%s - %d%s](%s) within 2 minutes to authenticate.",
+		prob.Name, prob.ContestID, prob.Index, probLink)
+	_, err := s.ChannelMessageSend(m.ChannelID, msgStr)
 	return err
 }
 

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -1,0 +1,98 @@
+package codeforces
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+type submissionList struct {
+	Submissions []submission `json:"result"`
+	Status      string       `json:"status"`
+	Comment     string       `json:"comment,omitempty"`
+}
+
+type submission struct {
+	ID                  int   `json:"id"`
+	ContestID           int   `json:"contestId"`
+	CreationTimeSeconds int64 `json:"creationTimeSeconds"`
+	RelativeTimeSeconds int   `json:"relativeTimeSeconds"`
+	Problem             struct {
+		ContestID int    `json:"contestId"`
+		Index     string `json:"index"`
+		Name      string `json:"name"`
+	}
+	Verdict string `json:"verdict"`
+}
+
+func startAuthCheck(handle string, contID int, problemIdx string, timeoutSeconds int, resultChan chan<- bool) {
+	startTime := time.Now().Unix()
+	log.Printf("Starting codeforces authentication for user '%s'.", handle)
+	go func() {
+		for {
+			// Stop if elapsed time has exceeded the timeout limit
+			if time.Now().Unix()-startTime > int64(timeoutSeconds) {
+				return
+			}
+			// Check every 5 seconds
+			time.Sleep(time.Second * 5)
+			// Get submissions and check if any of them match the criteria
+			subs, err := getSubmissions(handle, 5)
+			if err != nil {
+				log.Printf("Failed to get submissions from user '%s': %v", handle, err)
+			}
+			if checkSubmissions(subs, startTime, contID, problemIdx) {
+				resultChan <- true
+				close(resultChan)
+				return
+			}
+		}
+	}()
+}
+
+func checkSubmissions(subs []submission, startTime int64, contID int, problemIdx string) bool {
+	for _, sub := range subs {
+		// Ensure that submission was made after command was initiated
+		if sub.CreationTimeSeconds-startTime < 0 {
+			return false
+		}
+		correctID := sub.Problem.ContestID == contID
+		correctIdx := sub.Problem.Index == problemIdx
+		compilationError := sub.Verdict == "COMPILATION_ERROR"
+		if correctID && correctIdx && compilationError {
+			return true
+		}
+	}
+	return false
+}
+
+func getSubmissions(handle string, count int) (submissions []submission, err error) {
+	apiStr := fmt.Sprintf("https://codeforces.com/api/user.status?handle=%s&from=1&count=%d", handle, count)
+	res, err := http.Get(apiStr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err == nil {
+			err = res.Body.Close()
+		}
+	}()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var apiStruct submissionList
+	err = json.Unmarshal(body, &apiStruct)
+
+	if apiStruct.Status == "FAILED" {
+		return nil, errors.New(apiStruct.Comment)
+	}
+
+	return apiStruct.Submissions, err
+}

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/yuqzii/konkurransetilsynet/internal/utilCommands"
 )
 
 type submissionList struct {
@@ -47,8 +48,24 @@ type problem struct {
 	Type      string `json:"type"`
 }
 
+func authCommand(args []string, s *discordgo.Session, m *discordgo.MessageCreate) error {
+	// Ensure correct argument count
+	if len(args) < 3 {
+		err := utilCommands.UnknownCommand(s, m)
+		return err
+	}
+	// Start authentication goroutine
+	go func() {
+		err := authenticate(args[2], s, m)
+		if err != nil {
+			log.Println("Authentication failed: ", err)
+		}
+	}()
+	return nil
+}
+
 func authenticate(handle string, s *discordgo.Session, m *discordgo.MessageCreate) error {
-	log.Printf("Received authenticate for user '%s'.", handle)
+	log.Printf("Received codeforces authenticate for handle '%s'.", handle)
 	prob, err := getRandomProblem()
 	if err != nil {
 		return fmt.Errorf("failed to get a random problem: %w", err)

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -159,7 +159,7 @@ func authenticate(handle string, s *discordgo.Session, m *discordgo.MessageCreat
 
 	const debug bool = true
 	if debug {
-		var testProblem *problem = &problem{
+		var testProblem = &problem{
 			ContestID: 1627,
 			Index:     "C",
 			Name:      "Not Assigning",

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -66,7 +66,7 @@ func authCommand(args []string, s *discordgo.Session, m *discordgo.MessageCreate
 	if err != pgx.ErrNoRows {
 		if err != nil {
 			log.Println("Failed to check in database:", err)
-		} else if connectedHandle == "" {
+		} else if connectedHandle != "" {
 			err = onAlreadyConnected(connectedHandle, s, m)
 			if err != nil {
 				log.Println("Failed to send already connected message:", err)

--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -150,7 +150,10 @@ func authenticate(handle string, s *discordgo.Session, m *discordgo.MessageCreat
 	}
 	//prob = testProblem
 
-	sendAuthInstructions(prob, s, m)
+	err = sendAuthInstructions(prob, s, m)
+	if err != nil {
+		return fmt.Errorf("failed to send auth instructions: %w", err)
+	}
 
 	authChan := make(chan bool)
 	startAuthCheck(handle, prob.ContestID, prob.Index, 120, authChan)
@@ -248,7 +251,7 @@ func getRandomProblem() (prob *problem, err error) {
 		return nil, fmt.Errorf("failed to get problems: %w", err)
 	}
 	if len(problems) == 0 {
-		return nil, errors.New("cannot get random problem from empty slice.")
+		return nil, errors.New("cannot get random problem from empty slice")
 	}
 
 	// Max rating for Codeforces so that most can solve it after submitting compilation error

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -3,6 +3,7 @@ package codeforces
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -77,6 +78,11 @@ func HandleCodeforcesCommands(args []string, s *discordgo.Session, m *discordgo.
 		err := addDebugContestCommand(args, s, m)
 		if err != nil {
 			return errors.Join(errors.New("adding debug contest failed,"), err)
+		}
+	case "authenticate":
+		err := authCommand(args, s, m)
+		if err != nil {
+			return fmt.Errorf("authentication command failed: %w", err)
 		}
 	default:
 		err := utilCommands.UnknownCommand(s, m)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -67,7 +67,7 @@ func AddCodeforcesUser(discID, handle string) error {
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 
-	queryStr := fmt.Sprintf("INSERT INTO user_data (discord_id, codeforces_name) VALUES (%s, '%s');",
+	queryStr := fmt.Sprintf("INSERT INTO user_data (discord_id, codeforces_handle) VALUES (%s, '%s');",
 		discID, handle)
 	_, err = tx.Exec(context.Background(), queryStr)
 	if err != nil {
@@ -88,7 +88,7 @@ func UpdateCodeforcesUser(discID, handle string) error {
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 
-	queryStr := fmt.Sprintf("UPDATE user_data SET codeforces_name='%s' WHERE discord_id=%s;", handle, discID)
+	queryStr := fmt.Sprintf("UPDATE user_data SET codeforces_handle='%s' WHERE discord_id=%s;", handle, discID)
 	_, err = tx.Exec(context.Background(), queryStr)
 	if err != nil {
 		return fmt.Errorf("failed to update the codeforces handle belonging to discord id %s to '%s': %w",
@@ -103,7 +103,7 @@ func UpdateCodeforcesUser(discID, handle string) error {
 }
 
 func GetConnectedCodeforces(discID, handle string) (connectedHandle string, err error) {
-	queryStr := fmt.Sprintf("SELECT codeforces_name FROM user_data WHERE discord_id='%s';", discID)
+	queryStr := fmt.Sprintf("SELECT codeforces_handle FROM user_data WHERE discord_id='%s';", discID)
 	err = dbconn.QueryRow(context.Background(), queryStr).Scan(&connectedHandle)
 	if err != nil {
 		return "", err

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -66,7 +66,7 @@ func AddCodeforcesUser(discID, handle string) error {
 	if err != nil {
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
-	defer tx.Rollback(context.Background())
+	defer tx.Rollback(context.Background()) // nolint: errcheck
 
 	_, err = tx.Exec(context.Background(),
 		"INSERT INTO user_data (discord_id, codeforces_handle) VALUES ($1, $2);", discID, handle)
@@ -87,7 +87,7 @@ func UpdateCodeforcesUser(discID, handle string) error {
 	if err != nil {
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
-	defer tx.Rollback(context.Background())
+	defer tx.Rollback(context.Background()) // nolint: errcheck
 
 	_, err = tx.Exec(context.Background(),
 		"UPDATE user_data SET codeforces_handle=$1 WHERE discord_id=$2;", handle, discID)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -66,6 +66,7 @@ func AddCodeforcesUser(discID, handle string) error {
 	if err != nil {
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
+	defer tx.Rollback(context.Background())
 
 	_, err = tx.Exec(context.Background(),
 		"INSERT INTO user_data (discord_id, codeforces_handle) VALUES ($1, $2);", discID, handle)
@@ -86,6 +87,7 @@ func UpdateCodeforcesUser(discID, handle string) error {
 	if err != nil {
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
+	defer tx.Rollback(context.Background())
 
 	_, err = tx.Exec(context.Background(),
 		"UPDATE user_data SET codeforces_handle=$1 WHERE discord_id=$2;", handle, discID)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -65,3 +65,13 @@ func AddCodeforcesUser(discID, cfName string) error {
 	}
 	return nil
 }
+
+func GetConnectedCodeforces(discID, handle string) (connectedHandle string, err error) {
+	queryStr := fmt.Sprintf("SELECT codeforces_name FROM user_data WHERE discord_id='%s'", discID)
+	err = dbconn.QueryRow(context.Background(), queryStr).Scan(&connectedHandle)
+	if err != nil {
+		return "", err
+	}
+
+	return connectedHandle, nil
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -55,7 +55,7 @@ func AddCodeforcesUser(discID, cfName string) error {
 		fmt.Sprintf("INSERT INTO user_data (discord_id, codeforces_name) VALUES (%s, '%s');",
 			discID, cfName))
 	if err != nil {
-		return fmt.Errorf("failed to insert discord id %s and codeforces name %s into user_data: %w",
+		return fmt.Errorf("failed to insert discord id %s and codeforces name '%s' into user_data: %w",
 			discID, cfName, err)
 	}
 


### PR DESCRIPTION
Closes #53 and closes #52.
Authentication first checks whether the Discord user is already connected to a Codeforces user, if not it checks if there exists a user with the handle provided by the Discord user in the command. It then starts the authentication process, which starts with getting a random problem with a rating <= 1500 (so that most people can solve the problem afterwards if they wish). It then waits for a compilation error to be submitted to this problem, and if it detects one the authentication is successfull. Depending on whether or not the Discord user already exists in the database it will either insert a new row, or update the existing one with the Codeforces handle provided.