### PR TITLE
feat: codeforces leaderboard

### DIFF
--- a/internal/codeforces/authenticate.go
+++ b/internal/codeforces/authenticate.go
@@ -68,7 +68,7 @@ func authCommand(args []string, s *discordgo.Session, m *discordgo.MessageCreate
 	log.Printf("Received Codeforces authenticate for user with handle '%s' from %s (%s).",
 		args[2], m.Author.ID, m.Author.Username)
 
-	connectedHandle, err := database.GetConnectedCodeforces(m.Author.ID, args[2])
+	connectedHandle, err := database.GetConnectedCodeforces(m.Author.ID)
 	// ErrNoRows expected when user is not already connected
 	if err != pgx.ErrNoRows {
 		if err != nil {

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -59,7 +59,10 @@ func Init(s *discordgo.Session) error {
 	var guilds []*discordgo.Guild
 	copy(guilds, s.State.Guilds) // Deep copy to ensure the same list is used for all initialization
 	if err := updatePingData(s, guilds); err != nil {
-		return err
+		return fmt.Errorf("initializing contest ping data: %w", err)
+	}
+	if err := updateLeaderboardGuildData(s, guilds); err != nil {
+		return fmt.Errorf("initializing leaderboard guild data: %w", err)
 	}
 	startContestPingCheck(&upcoming, 1*time.Minute, s)
 	return nil

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -89,11 +89,6 @@ func HandleCodeforcesCommands(args []string, s *discordgo.Session, m *discordgo.
 		if err != nil {
 			return fmt.Errorf("authentication command failed: %w", err)
 		}
-	case "leaderboard":
-		err := sendLeaderboardMessage(m.GuildID, m.ChannelID, s)
-		if err != nil {
-			return fmt.Errorf("sending leaderboard message: %w", err)
-		}
 	default:
 		err := utilCommands.UnknownCommand(s, m)
 		return err
@@ -156,6 +151,7 @@ func addContest(contests *contestList, id uint32, name string, startTime uint32)
 		Name:             name,
 		StartTimeSeconds: startTime,
 		DurationSeconds:  60,
+		WebsiteURL:       "https://codeforces.com/contests",
 	})
 
 	// Update contests to our slice containing the new element
@@ -172,7 +168,7 @@ func updateUpcoming(s *discordgo.Session, listToUpdate *contestList) error {
 	for _, c := range listToUpdate.contests {
 		hasEnded := t >= int64(c.StartTimeSeconds)+int64(c.DurationSeconds)
 		if hasEnded {
-			go onContestEnd(s)
+			go onContestEnd(s, c)
 		}
 	}
 
@@ -244,6 +240,6 @@ func filterContests(contests []contest, f func(*contest) bool) (result []contest
 	return result
 }
 
-func onContestEnd(s *discordgo.Session) {
-	go sendLeaderboardMessageAll(s)
+func onContestEnd(s *discordgo.Session, c contest) {
+	go sendLeaderboardMessageAll(s, &c)
 }

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -169,12 +169,9 @@ func addContest(contests *contestList, id uint32, name string, startTime uint32)
 func updateUpcoming(s *discordgo.Session, listToUpdate *contestList) error {
 	// Check if any contest has ended
 	t := time.Now().Unix()
-	log.Printf("Cur time: %d", t)
 	for _, c := range listToUpdate.contests {
 		hasEnded := t >= int64(c.StartTimeSeconds)+int64(c.DurationSeconds)
-		log.Printf("End time: %d", c.StartTimeSeconds+c.DurationSeconds)
 		if hasEnded {
-			log.Printf("contest %s has ended", c.Name)
 			go onContestEnd(s)
 		}
 	}

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -89,6 +89,11 @@ func HandleCodeforcesCommands(args []string, s *discordgo.Session, m *discordgo.
 		if err != nil {
 			return fmt.Errorf("authentication command failed: %w", err)
 		}
+	case "leaderboard":
+		err := sendLeaderboardMessage(m.GuildID, m.ChannelID, s)
+		if err != nil {
+			return fmt.Errorf("sending leaderboard message: %w", err)
+		}
 	default:
 		err := utilCommands.UnknownCommand(s, m)
 		return err

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -55,8 +55,8 @@ type contestList struct {
 var upcoming = contestList{}
 
 func Init(s *discordgo.Session) error {
-	startContestUpdate(&upcoming, 1*time.Hour)
-	var guilds []*discordgo.Guild
+	startContestUpdate(s, &upcoming, 1*time.Hour)
+	guilds := make([]*discordgo.Guild, len(s.State.Guilds))
 	copy(guilds, s.State.Guilds) // Deep copy to ensure the same list is used for all initialization
 	if err := updatePingData(s, guilds); err != nil {
 		return fmt.Errorf("initializing contest ping data: %w", err)

--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -56,7 +56,9 @@ var upcoming = contestList{}
 
 func Init(s *discordgo.Session) error {
 	startContestUpdate(&upcoming, 1*time.Hour)
-	if err := updatePingData(s); err != nil {
+	var guilds []*discordgo.Guild
+	copy(guilds, s.State.Guilds) // Deep copy to ensure the same list is used for all initialization
+	if err := updatePingData(s, guilds); err != nil {
 		return err
 	}
 	startContestPingCheck(&upcoming, 1*time.Minute, s)

--- a/internal/codeforces/createChannelRole.go
+++ b/internal/codeforces/createChannelRole.go
@@ -1,0 +1,97 @@
+package codeforces
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// @abstract	Creates a channel in every guild if it does not already have one
+// @return		Slice of channel IDs, one for each guild. Includes preexisting channels with the name.
+func createChannelIfNotExist(s *discordgo.Session, channelName string, guilds []*discordgo.Guild) (result []string, err error) {
+	for _, guild := range guilds {
+		channel, err := getChannelIDByName(channelName, guild.ID, s)
+		if err != nil {
+			return nil, fmt.Errorf("getting channel ID of '%s' in guild %s: %w", channelName, guild.ID, err)
+		}
+
+		// Create new channel if there does not exist one
+		if channel == "" {
+			newChannel, err := s.GuildChannelCreate(guild.ID, channelName, discordgo.ChannelTypeGuildText)
+			if err != nil {
+				return nil, fmt.Errorf("creating channel '%s' in guild %s: %w", channelName, guild.ID, err)
+			}
+			channel = newChannel.ID
+		}
+
+		result = append(result, channel)
+	}
+
+	return result, nil
+}
+
+// @return	ID of the channel as a string, empty ("") if there is no channel with the provided name.
+func getChannelIDByName(name string, guildID string, s *discordgo.Session) (string, error) {
+	channels, err := s.GuildChannels(guildID)
+	if err != nil {
+		return "", err
+	}
+
+	// Try to find a channel with the name
+	for _, channel := range channels {
+		// Skip non-text channels
+		if channel.Type != discordgo.ChannelTypeGuildText {
+			continue
+		}
+
+		if channel.Name == name {
+			return channel.ID, nil
+		}
+	}
+
+	return "", nil
+}
+
+// @abstract	Creates a role in every guild if it does not already have one.
+// @return		Slice of role IDs, one for each guild. Includes preexisting roles with the name.
+func createRoleIfNotExists(s *discordgo.Session, roleName string, guilds []*discordgo.Guild) (result []string, err error) {
+	for _, guild := range guilds {
+		role, err := getRoleIDByName(roleName, guild.ID, s)
+		if err != nil {
+			return nil, fmt.Errorf("getting role ID of '%s' in guild %s: %w", roleName, guild.ID, err)
+		}
+
+		// Create new role if there does not exist one
+		if role == "" {
+			newRole, err := s.GuildRoleCreate(guild.ID, &discordgo.RoleParams{
+				Name: roleName,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("creating role '%s' in guild %s: %w", roleName, guild.ID, err)
+			}
+
+			role = newRole.ID
+		}
+
+		result = append(result, role)
+	}
+
+	return result, nil
+}
+
+// @return	ID of the role as a string, empty ("") if there is no role with the provided name.
+func getRoleIDByName(name string, guildID string, s *discordgo.Session) (string, error) {
+	roles, err := s.GuildRoles(guildID)
+	if err != nil {
+		return "", err
+	}
+
+	// Try to find role with correct name
+	for _, role := range roles {
+		if role.Name == name {
+			return role.ID, nil
+		}
+	}
+
+	return "", nil
+}

--- a/internal/codeforces/leaderboard.go
+++ b/internal/codeforces/leaderboard.go
@@ -27,11 +27,16 @@ type ratingChange struct {
 }
 
 type lbGuildData struct {
-	channels []string // Slice of channel IDs
-	mu       sync.RWMutex
+	guildID   string
+	channelID string
 }
 
-var guildData lbGuildData
+type lbGuildDataList struct {
+	data []lbGuildData
+	mu   sync.RWMutex
+}
+
+var guildData lbGuildDataList
 
 func updateLeaderboardGuildData(s *discordgo.Session, guilds []*discordgo.Guild) error {
 	channels, err := createChannelIfNotExist(s, channelName, guilds)
@@ -39,8 +44,13 @@ func updateLeaderboardGuildData(s *discordgo.Session, guilds []*discordgo.Guild)
 		return err
 	}
 
+	var newData []lbGuildData
+	for i := range channels {
+		newData = append(newData, lbGuildData{guilds[i].ID, channels[i]})
+	}
+
 	guildData.mu.Lock()
-	guildData.channels = channels
+	guildData.data = newData
 	guildData.mu.Unlock()
 	return nil
 }

--- a/internal/codeforces/leaderboard.go
+++ b/internal/codeforces/leaderboard.go
@@ -55,6 +55,21 @@ func updateLeaderboardGuildData(s *discordgo.Session, guilds []*discordgo.Guild)
 	return nil
 }
 
+// @abstract	Sends a leaderboard message for every guild the bot is in.
+func sendLeaderboardMessageAll(s *discordgo.Session) {
+	guildData.mu.RLock()
+	defer guildData.mu.RUnlock()
+
+	for _, data := range guildData.data {
+		go func() {
+			err := sendLeaderboardMessage(data.guildID, data.channelID, s)
+			if err != nil {
+				log.Printf("Error sending leaderboard message to all guilds (guild %s): %s", data.guildID, err)
+			}
+		}()
+	}
+}
+
 func sendLeaderboardMessage(guildID string, channelID string, s *discordgo.Session) error {
 	ratings, err := getRatingsInGuild(guildID, s)
 	if err != nil {

--- a/internal/codeforces/leaderboard.go
+++ b/internal/codeforces/leaderboard.go
@@ -1,0 +1,43 @@
+package codeforces
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type ratingChange struct {
+	OldRating int `json:"oldRating"`
+	NewRating int `json:"newRating"`
+}
+
+func getRating(handle string) (rating *ratingChange, err error) {
+	apiStr := fmt.Sprintf("https://codeforces.com/api/user.rating?handle=%s", handle)
+	res, err := http.Get(apiStr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, res.Body.Close())
+	}()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	type apiReturn struct {
+		Status  string         `json:"status"`
+		Comment string         `json:"comment"`
+		Result  []ratingChange `json:"result"`
+	}
+	var api apiReturn
+	err = json.Unmarshal(body, &api)
+	if api.Status == "FAILED" {
+		return nil, errors.New(api.Comment)
+	}
+
+	return &api.Result[0], err
+}

--- a/internal/codeforces/leaderboard.go
+++ b/internal/codeforces/leaderboard.go
@@ -6,11 +6,34 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/jackc/pgx/v5"
+	"github.com/yuqzii/konkurransetilsynet/internal/database"
 )
 
 type ratingChange struct {
 	OldRating int `json:"oldRating"`
 	NewRating int `json:"newRating"`
+}
+
+func getCodeforcesInGuild(guildID string, s *discordgo.Session) (result []string, err error) {
+	guild, err := s.State.Guild(guildID)
+	if err != nil {
+		return nil, fmt.Errorf("getting guild from id %s: %w", guildID, err)
+	}
+
+	for _, member := range guild.Members {
+		handle, err := database.GetConnectedCodeforces(member.User.ID)
+		// ErrNoRows expected if the user has not connected their Codeforces
+		if err != nil && err != pgx.ErrNoRows {
+			return nil, fmt.Errorf("getting Codeforces handle of %s (%s): %w",
+				member.User.ID, member.User.Username, err)
+		}
+		result = append(result, handle)
+	}
+
+	return result, nil
 }
 
 func getRating(handle string) (rating *ratingChange, err error) {

--- a/internal/codeforces/leaderboard.go
+++ b/internal/codeforces/leaderboard.go
@@ -154,5 +154,5 @@ func getRating(handle string) (rating *ratingChange, err error) {
 		return nil, errors.New(api.Comment)
 	}
 
-	return &api.Result[0], err
+	return &api.Result[len(api.Result)-1], err
 }

--- a/internal/codeforces/leaderboard.go
+++ b/internal/codeforces/leaderboard.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"sort"
 	"sync"
 
 	"github.com/bwmarrin/discordgo"
@@ -18,8 +20,9 @@ const (
 )
 
 type ratingChange struct {
-	OldRating int `json:"oldRating"`
-	NewRating int `json:"newRating"`
+	Handle    string `json:"handle"`
+	OldRating int    `json:"oldRating"`
+	NewRating int    `json:"newRating"`
 }
 
 type lbGuildData struct {
@@ -41,20 +44,85 @@ func updateLeaderboardGuildData(s *discordgo.Session, guilds []*discordgo.Guild)
 	return nil
 }
 
+func sendLeaderboardMessage(guildID string, channelID string, s *discordgo.Session) error {
+	handles, err := getCodeforcesInGuild(guildID, s)
+	if err != nil {
+		return fmt.Errorf("getting codeforces handles in %s: %w", guildID, err)
+	}
+
+	if len(handles) == 0 {
+		log.Printf("No connected Codeforces in guild %s. Not sending leaderboard message.", guildID)
+		return nil
+	}
+
+	ratingChan := make(chan *ratingChange)
+	for _, handle := range handles {
+		go func() {
+			rating, err := getRating(handle)
+			if err != nil {
+				log.Printf("Getting Codeforces rating from handle %s failed: %s", handle, err)
+				return
+			}
+			ratingChan <- rating
+		}()
+	}
+
+	var ratings []*ratingChange
+	for range len(handles) {
+		rating := <-ratingChan
+		ratings = append(ratings, rating)
+	}
+
+	// Sort by new rating
+	sort.Slice(ratings, func(i, j int) bool {
+		return ratings[i].NewRating > ratings[j].NewRating
+	})
+
+	messageStr := ""
+	for i, rating := range ratings {
+		messageStr += fmt.Sprintf("%d. %s (%d)\n", i+1, rating.Handle, rating.NewRating)
+	}
+
+	_, err = s.ChannelMessageSend(channelID, messageStr)
+	if err != nil {
+		return fmt.Errorf("sending leaderboard message: %w", err)
+	}
+
+	return nil
+}
+
 func getCodeforcesInGuild(guildID string, s *discordgo.Session) (result []string, err error) {
 	guild, err := s.State.Guild(guildID)
 	if err != nil {
 		return nil, fmt.Errorf("getting guild from id %s: %w", guildID, err)
 	}
 
-	for _, member := range guild.Members {
-		handle, err := database.GetConnectedCodeforces(member.User.ID)
+	// Helper lambda to avoid duplicate code in member loop and owner
+	getCodeforcesFromID := func(id string) error {
+		handle, err := database.GetConnectedCodeforces(id)
 		// ErrNoRows expected if the user has not connected their Codeforces
 		if err != nil && err != pgx.ErrNoRows {
-			return nil, fmt.Errorf("getting Codeforces handle of %s (%s): %w",
-				member.User.ID, member.User.Username, err)
+			return fmt.Errorf("getting Codeforces handle of %s: %w", id, err)
 		}
-		result = append(result, handle)
+
+		if handle != "" {
+			result = append(result, handle)
+		}
+
+		return nil
+	}
+
+	for _, member := range guild.Members {
+		err = getCodeforcesFromID(member.User.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// guild.Members does for some reason not include owner, this includes the owner in the leaderboard
+	err = getCodeforcesFromID(guild.OwnerID)
+	if err != nil {
+		return nil, err
 	}
 
 	return result, nil

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -103,7 +103,7 @@ func UpdateCodeforcesUser(discID, handle string) error {
 	return nil
 }
 
-func GetConnectedCodeforces(discID, handle string) (connectedHandle string, err error) {
+func GetConnectedCodeforces(discID string) (connectedHandle string, err error) {
 	err = dbconn.QueryRow(context.Background(),
 		"SELECT codeforces_handle FROM user_data WHERE discord_id=$1", discID).Scan(&connectedHandle)
 	if err != nil {


### PR DESCRIPTION
Closes #54 
- General function for automatically adding channels and roles to servers on startup.
- Creates a leaderboard channel using this function.
- Add event that fires whenever a contest ends.
- Waits until Codeforces has updated ratings before sending the leaderboard message.

Decided to not have a separate command for sending the leaderboard, as one can always just check the created leaderboard channel (could be that some laziness was also involved).