### PR TITLE
feat(ci): stop removing deployments

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -12,13 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Delete previous deployments
-        uses: strumwolf/delete-deployment-environment@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment: "development"
-          onlyRemoveDeployments: true
-
       - name: Deploy bot
         run: docker compose --profile dev up -d --build
         env:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -13,13 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Delete previous deployments
-        uses: strumwolf/delete-deployment-environment@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment: "production"
-          onlyRemoveDeployments: true
-
       - name: Deploy bot
         run: docker compose --profile prod up -d --build
         env:


### PR DESCRIPTION
Updated the workflow files to not delete old deployments.
This was only here to remove deployments when we were experimenting with how the deployment should work, so that we didn't have a long record of useless deploys.