### PR TITLE
fix: codeforces rating update

### DIFF
--- a/internal/codeforces/codeforces.go
+++ b/internal/codeforces/codeforces.go
@@ -107,7 +107,7 @@ func (h *Handler) getGuilds() []*discordgo.Guild {
 	return res
 }
 
-func (h *Handler) onContestEnd(c *contest) {
+func (h *Handler) onContestFinish(c *contest) {
 	ratingUpdates := h.leaderboard.startRatingUpdateCheck(c)
 	for updated := range ratingUpdates {
 		if updated {


### PR DESCRIPTION
Fixes #64
- Changed name of what was previously referred to as contest end to contest finish.
- Introduced new contest state called end, which it is in until we get that it is in FINISHED from Codeforces. Only then calls onContestFinish.

This *should* fix the issue, but we will have to see how it behaves with the real Codeforces API (documentation was not very clear on this stuff).