### PR TITLE
fix: spaces in gtf guess not working

### DIFF
--- a/internal/guessTheFunction/guessTheFunction.go
+++ b/internal/guessTheFunction/guessTheFunction.go
@@ -108,7 +108,7 @@ func HandleGuessTheFunctionCommands(args []string, s *discordgo.Session, m *disc
 			return err
 		}
 	case "guess":
-		guessFunc := args[2]
+		guessFunc := strings.Join(args[2:], "")
 		correct, err := guess(guessFunc, activeRounds[m.ChannelID])
 		if err != nil {
 			if errors.Is(err, ErrLex) {


### PR DESCRIPTION
Fixes #79 
Problem:
It only took arg[2] as the function definition, and because the args are separated by spaces, it didn't register the entire definition if it contained spaces.

Solution:
Join all arguments after 2 and remove spaces.