### PR TITLE
feat: db migration

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Deploy bot
-        run: docker compose --profile dev up -d --build
+        run: make PROFILE=dev DETACHED=-d
         env:
           TOKEN: ${{ secrets.TOKEN }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Deploy bot
-        run: docker compose --profile prod up -d --build
+        run: make PROFILE=prod DETACHED=-d
         env:
           TOKEN: ${{ secrets.TOKEN }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 PROFILE ?= dev
+DETACHED ?= # Set to -d to start as detached (used when deploying)
 
 default: build run
 
 run:
-	docker-compose --profile $(PROFILE) up
+	docker-compose --profile $(PROFILE) up $(DETACHED)
 
 build:
 	docker compose --profile $(PROFILE) build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+PROFILE ?= dev
+
+default: build run
+
+run:
+	docker-compose --profile $(PROFILE) up
+
+build:
+	docker compose --profile $(PROFILE) build
+
+migrate-down:
+	docker compose --profile $(PROFILE) run --rm dev-migrate-down $(COUNT)
+
+db-shell:
+	docker-compose exec db psql -U postgres bot_data
+
+dev-db-shell:
+	docker-compose exec dev-db psql -U postgres bot_data

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,7 +30,6 @@ const (
 	contestUpdateInterval    time.Duration = 1 * time.Hour
 	contestPingCheckInterval time.Duration = 1 * time.Minute
 
-	dbHost string = "db"
 	dbUser string = "postgres"
 	dbName string = "bot_data"
 	dbPort uint16 = 5432
@@ -50,6 +49,7 @@ func main() {
 
 	// Connect to database
 	dbPassword := os.Getenv("POSTGRES_PASSWORD")
+	dbHost := os.Getenv("DB_HOST")
 	db, err := database.New(context.Background(), dbHost, dbUser, dbPassword, dbName, dbPort)
 	if err != nil {
 		log.Fatal("Could not connect to database: ", err)

--- a/dbinit/user_data.sql
+++ b/dbinit/user_data.sql
@@ -1,7 +1,0 @@
-CREATE TABLE IF NOT EXISTS user_data (
-	discord_id NUMERIC(20) NOT NULL,
-	codeforces_handle VARCHAR(255)
-);
-
-ALTER TABLE user_data
-ADD CONSTRAINT unique_discord_id UNIQUE(discord_id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,32 @@
+x-postgres-common: &postgres-common
+  image: postgres:17.5
+  restart: always
+  environment:
+    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    - POSTGRES_DB=bot_data
+  healthcheck:
+    test: ["CMD-SHELL", "pg_isready -U postgres -d bot_data"]
+    interval: 5s
+    retries: 10
+    start_period: 10s
+    timeout: 10s
+
+x-migrate-common: &migrate-common
+  image: migrate/migrate:v4.19.0
+  volumes:
+    - ./migrations:/migrations:ro,z
+  environment:
+    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+  restart: no
+
+x-migrate-down-common: &migrate-down-common
+  image: migrate/migrate:v4.19.0
+  volumes:
+    - ./migrations:/migrations:ro,z
+  environment:
+    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+  restart: no
+
 services:
   prod-bot:
     build: ./
@@ -5,6 +34,7 @@ services:
     environment:
       - TOKEN=${TOKEN}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - DB_HOST=db
     profiles: [prod]
     depends_on:
       migrate:
@@ -17,59 +47,76 @@ services:
       - TOKEN=${TOKEN}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - DEBUG=${DEBUG}
+      - DB_HOST=dev-db
     profiles: [dev]
     depends_on:
-      migrate:
+      dev-migrate:
         condition: service_completed_successfully
 
   db:
-    image: postgres:17.5
-    restart: always
-    environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=bot_data
+    <<: *postgres-common
+    profiles: [prod]
     volumes:
       - konktils-db:/var/lib/postgresql/data 
     ports:
-      - "5432:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d bot_data"]
-      interval: 5s
-      retries: 10
-      start_period: 10s
-      timeout: 10s
+      - 5432:5432
+
+  dev-db:
+    <<: *postgres-common
+    profiles: [dev]
+    volumes:
+      - konktils-db-dev:/var/lib/postgresql/data
+    ports:
+      - 5433:5432
 
   migrate:
-    image: migrate/migrate:v4.19.0
+    <<: *migrate-common
+    profiles: [prod]
     depends_on:
       db:
         condition: service_healthy
-    volumes:
-      - ./migrations:/migrations:ro,z
-    environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     command: [
-      "-path", "/migrations",
-      "-database", "postgres://postgres:${POSTGRES_PASSWORD}@db:5432/bot_data?sslmode=disable",
-      "up"
+        "-path", "/migrations",
+        "-database", "postgres://postgres:${POSTGRES_PASSWORD}@db:5432/bot_data?sslmode=disable",
+        "up"
     ]
-    restart: "no"
+
+  dev-migrate:
+    <<: *migrate-common
+    profiles: [dev]
+    depends_on:
+      dev-db:
+        condition: service_healthy
+    command: [
+        "-path", "/migrations",
+        "-database", "postgres://postgres:${POSTGRES_PASSWORD}@dev-db:5432/bot_data?sslmode=disable",
+        "up"
+    ]
 
   migrate-down:
-    image: migrate/migrate:v4.19.0
+    <<: *migrate-down-common
     profiles: [migrate-down]
     depends_on:
       db:
         condition: service_healthy
-    volumes:
-      - ./migrations:/migrations:ro,z
-    environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     entrypoint: [
-      "migrate", "-path", "/migrations",
-      "-database", "postgres://postgres:${POSTGRES_PASSWORD}@db:5432/bot_data?sslmode=disable",
-      "down"
+        "migrate", "-path", "/migrations",
+        "-database", "postgres://postgres:${POSTGRES_PASSWORD}@db:5432/bot_data?sslmode=disable",
+        "down"
+    ]
+
+  dev-migrate-down:
+    <<: *migrate-down-common
+    profiles: [dev-migrate-down]
+    depends_on:
+      dev-db:
+        condition: service_healthy
+    entrypoint: [
+        "migrate", "-path", "/migrations",
+        "-database", "postgres://postgres:${POSTGRES_PASSWORD}@dev-db:5432/bot_data?sslmode=disable",
+        "down"
     ]
 
 volumes:
   konktils-db:
+  konktils-db-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,5 +55,21 @@ services:
     ]
     restart: "no"
 
+  migrate-down:
+    image: migrate/migrate:v4.19.0
+    profiles: [migrate-down]
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ./migrations:/migrations:ro,z
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    entrypoint: [
+      "migrate", "-path", "/migrations",
+      "-database", "postgres://postgres:${POSTGRES_PASSWORD}@db:5432/bot_data?sslmode=disable",
+      "down"
+    ]
+
 volumes:
   konktils-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     profiles: [prod]
     depends_on:
-      db:
-        condition: service_healthy
-        restart: true
+      migrate:
+        condition: service_completed_successfully
 
   dev-bot:
     build: ./
@@ -20,9 +19,8 @@ services:
       - DEBUG=${DEBUG}
     profiles: [dev]
     depends_on:
-      db:
-        condition: service_healthy
-        restart: true
+      migrate:
+        condition: service_completed_successfully
 
   db:
     image: postgres:17.5
@@ -32,7 +30,6 @@ services:
       - POSTGRES_DB=bot_data
     volumes:
       - konktils-db:/var/lib/postgresql/data 
-      - ./dbinit:/docker-entrypoint-initdb.d/:z
     ports:
       - "5432:5432"
     healthcheck:
@@ -41,6 +38,22 @@ services:
       retries: 10
       start_period: 10s
       timeout: 10s
+
+  migrate:
+    image: migrate/migrate:v4.19.0
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ./migrations:/migrations:ro,z
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    command: [
+      "-path", "/migrations",
+      "-database", "postgres://postgres:${POSTGRES_PASSWORD}@db:5432/bot_data?sslmode=disable",
+      "up"
+    ]
+    restart: "no"
 
 volumes:
   konktils-db:

--- a/migrations/0001_create_users_table.down.sql
+++ b/migrations/0001_create_users_table.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP TABLE IF EXISTS users;
+
+DROP FUNCTION IF EXISTS set_updated_at();
+
+COMMIT;

--- a/migrations/0001_create_users_table.up.sql
+++ b/migrations/0001_create_users_table.up.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS users (
+	discord_id NUMERIC(20) PRIMARY KEY,
+	codeforces_handle VARCHAR(255),
+	created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+	updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+	NEW.updated_at = NOW();
+	RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+
+CREATE TRIGGER trigger_set_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE PROCEDURE set_updated_at();
+
+COMMIT;

--- a/migrations/0001_create_users_table.up.sql
+++ b/migrations/0001_create_users_table.up.sql
@@ -13,7 +13,7 @@ BEGIN
 	NEW.updated_at = NOW();
 	RETURN NEW;
 END;
-$$ LANGUAGE plpgsql
+$$ LANGUAGE plpgsql;
 
 CREATE TRIGGER trigger_set_updated_at
 BEFORE UPDATE ON users


### PR DESCRIPTION
Closes #63 
- Automatic db migration with golang-migrate.
- Change the name of user_data table to users, and include created_at and updated_at.
- Add Makefile for qol.

Plan is to nuke the db to ensure that the new migration system works properly. (Prod db literally has 2 rows so it should be fine).